### PR TITLE
Use `cospi` in the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,29 @@ As expected, this is much faster than the numeric integral solution
 ```julia
 using QuadGK
 using FresnelIntegrals
+using BenchmarkTools
 
 julia> @benchmark fresnelc(1.8)
-BenchmarkTools.Trial: 10000 samples with 772 evaluations.
- Range (min … max):  161.448 ns …  1.744 μs  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     163.927 ns              ┊ GC (median):    0.00%
- Time  (mean ± σ):   164.460 ns ± 16.519 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+BenchmarkTools.Trial: 10000 samples with 961 evaluations.
+ Range (min … max):  86.629 ns … 192.074 ns  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     89.056 ns               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   90.710 ns ±   5.423 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-  ▃▄▂                ▁▇█▄          ▁  ▃▄▂▁        ▁▁▁          ▂
-  ███▇▁▃▁▁▁▁▁▁▁▁▁▁▅▇▅█████▁▄▄▄▆▆▅▆▆█▇▆█████▇▆▅▅▇██████▇▇▆▇▇▆▅▆ █
-  161 ns        Histogram: log(frequency) by time       168 ns <
+  ▆▆█▅ ▇█▃ ▁▂▄▃ ▂▃▂▁▂▁▂▂▂▂▂▁▁▁  ▁     ▁                        ▂
+  ████▇███▇███████████████████████████████▇▇█▇▇▇▆▆▆▇▆▇▆▆▆▇▆▆▆▅ █
+  86.6 ns       Histogram: log(frequency) by time       111 ns <
 
  Memory estimate: 0 bytes, allocs estimate: 0.
 
-julia> @benchmark quadgk(t->cos(π*t^2/2),0,1.8)
-BenchmarkTools.Trial: 10000 samples with 187 evaluations.
- Range (min … max):  548.321 ns …  48.949 μs  ┊ GC (min … max): 0.00% … 98.43%
- Time  (median):     554.893 ns               ┊ GC (median):    0.00%
- Time  (mean ± σ):   599.010 ns ± 558.147 ns  ┊ GC (mean ± σ):  2.25% ±  3.29%
+julia> @benchmark quadgk(t->cospi(t^2/2),0,1.8)
+BenchmarkTools.Trial: 10000 samples with 201 evaluations.
+ Range (min … max):  394.697 ns …  2.443 μs  ┊ GC (min … max): 0.00% … 79.19%
+ Time  (median):     411.279 ns              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   424.133 ns ± 75.245 ns  ┊ GC (mean ± σ):  0.65% ±  3.09%
 
-  ▅█▆▂▄▃▃▁▁▁▁▁                    ▂▁                  ▁▁▁▁▂▁    ▁
-  ███████████████▇▅▆▅▄▃▅▄▅▅▅▄▄▃▄████████▇▇▆▆▇▆▆▆▇▇▇▇▇█████████▇ █
-  548 ns        Histogram: log(frequency) by time        754 ns <
+    ▄▄▂▂▄▇██▆▃▁▁▂▂▃▃▄▄▄▄▃▄▃▂▂▁▁▁▁▂▂▂▂▂▁▂▁                      ▂
+  ▂███████████████████████████████████████████▇▇█▇█▇▇▇▇▅▅▄▅▆▅▅ █
+  395 ns        Histogram: log(frequency) by time       499 ns <
 
  Memory estimate: 368 bytes, allocs estimate: 2.
 ```


### PR DESCRIPTION
Just a minor suggestion for the benchmark example. It does not seem to affect the general tendency of the results (differences are due to my seemingly faster computer), but I think one should generally prefer `cospi` over `cos(pi * ...)`.